### PR TITLE
fix: nullpointer if a product doesn't have a picture in grocy.

### DIFF
--- a/GrocyScanner.Core/GrocyClient/GrocyClient.cs
+++ b/GrocyScanner.Core/GrocyClient/GrocyClient.cs
@@ -74,12 +74,11 @@ public class GrocyClient : IGrocyClient
 
         JsonElement.ArrayEnumerator arrayEnumerator = jsonDocument.RootElement.EnumerateArray();
         arrayEnumerator.MoveNext();
-
         return new Product
         {
             Gtin = gtin,
             Name = arrayEnumerator.Current.GetProperty("name").GetString()!,
-            ImageUrl = $"{_grocyConfiguration.Value.BaseUrl}/api/files/productpictures/{Base64Encode(arrayEnumerator.Current.GetProperty("picture_file_name").GetString()!)}"
+            ImageUrl = $"{_grocyConfiguration.Value.BaseUrl}/api/files/productpictures/{Base64Encode(arrayEnumerator.Current.GetProperty("picture_file_name").GetString() ?? string.Empty)}"
         };
     }
 


### PR DESCRIPTION
This fixes an issue that occurs when you try to "purchase" a known product that does not have a picture in Grocy.