### PR TITLE
Feat: manuel-rw#5 Add support for small horizontal screens

### DIFF
--- a/GrocyScanner.Service/Pages/Scanner.razor
+++ b/GrocyScanner.Service/Pages/Scanner.razor
@@ -171,7 +171,8 @@
         {
             CloseOnEscapeKey = false,
             DisableBackdropClick = true,
-            CloseButton = false
+            CloseButton = false,
+            MaxWidth = MaxWidth.Large
         });
         await dialogReference.Result;
         await barcodeInputTextRef.FocusAsync();

--- a/GrocyScanner.Service/Shared/Components/AddProductDialog.razor
+++ b/GrocyScanner.Service/Shared/Components/AddProductDialog.razor
@@ -12,21 +12,18 @@
     <DialogContent>
         @if (Product != null)
         {
-            <MudCard Outlined="true">
-                @if (!string.IsNullOrEmpty(Product.ImageUrl))
-                {
-                    <div class="py-2 d-flex align-items-center justify-content-center">
-                        <img class="rounded" src="@Product.ImageUrl" height="150" alt="product image"/>
-                    </div>
-                }
-
+            <MudCard Outlined="true" Class="d-sm-flex flex-sm-start flex-sm-wrap d-lg-block">
                 <MudCardContent>
+                    @if (!string.IsNullOrEmpty(Product.ImageUrl))
+                    {
+                        <MudCardMedia Class="rounded" Image=@Product.ImageUrl Height="150"/>
+                    }
                     <MudText Typo="Typo.h5" Class="fw-bold">@Product.Gtin</MudText>
                     <MudText Typo="Typo.h4" Class="fw-bold">@Product.Name.Humanize()</MudText>
-
+                </MudCardContent>
+                <MudForm Class="m-3">
                     <MudDatePicker
                         Variant="Variant.Filled"
-                        Class="mt-4"
                         Label="Best before (optional)"
                         @bind-Date="FormBestBefore"
                         Margin="Margin.Dense"
@@ -39,7 +36,8 @@
                         Margin="Margin.Dense"
                         Variant="Variant.Filled"
                         Min="0.0"
-                        Max="int.MaxValue"/>
+                        Max="int.MaxValue"
+                        />
                     <MudNumericField
                         @bind-Value="FormAmount"
                         Format="N0"
@@ -47,9 +45,11 @@
                         Margin="Margin.Dense"
                         Variant="Variant.Filled"
                         Min="1"
-                        Max="999"/>
-                </MudCardContent>
+                        Max="999"
+                    />
+                    </MudForm>
             </MudCard>
+
         }
         @if (IsLoading)
         {
@@ -67,8 +67,7 @@
                 </MudCardContent>
             </MudCard>
         }
-        
-        <p>Requested at @ProductProviders.Count() providers</p>
+        <MudText>Requested at @ProductProviders.Count() providers</MudText>
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>


### PR DESCRIPTION
Adds support for a horizontal UI when the screen gets small.
![image](https://github.com/manuel-rw/grocy-scanner/assets/22870074/f09dbcff-75f2-47b8-a946-4b7feb22cb9f)

Reverts to the original design for large screens:
![image](https://github.com/manuel-rw/grocy-scanner/assets/22870074/f319c7b8-5eb2-487e-9162-20c34071d6b0)

And for very small screens:
![image](https://github.com/manuel-rw/grocy-scanner/assets/22870074/844c3d96-c851-41ab-b998-5cd108662901)
