### PR TITLE
Product retrieve error fix

### DIFF
--- a/GrocyScanner.Core/Providers/CoopProductProvider.cs
+++ b/GrocyScanner.Core/Providers/CoopProductProvider.cs
@@ -68,6 +68,11 @@ public class CoopProductProvider : IProductProvider
                 ImageUrl = GetBestQualityImage(element.Image)
             };
         }
+        catch (HttpRequestException httpRequestException) when (httpRequestException.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("Product not found in Coop: {Gtin}", gtin);
+            return null;
+        }
         catch (HttpRequestException httpRequestException)
         {
             _logger.LogError(httpRequestException, "Failed to fetch coop product: {Gtin} - {JsonResponse}", gtin,

--- a/GrocyScanner.Core/Providers/MigrosProductProvider.cs
+++ b/GrocyScanner.Core/Providers/MigrosProductProvider.cs
@@ -68,6 +68,11 @@ public class MigrosProductProvider : IProductProvider
                 ImageUrl = GetImageFromJsonDocument(arrayEnumerator.Current)
             };
         }
+        catch (HttpRequestException httpRequestException) when (httpRequestException.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("Product not found in Migros: {ProductIds}", productIds);
+            return null;
+        }
         catch (HttpRequestException httpRequestException)
         {
             _logger.LogError(httpRequestException,
@@ -121,6 +126,11 @@ public class MigrosProductProvider : IProductProvider
             using JsonDocument jsonDocument = JsonDocument.Parse(content);
             JsonElement productIdsElement = jsonDocument.RootElement.GetProperty("productIds");
             return productIdsElement.EnumerateArray().Select(jsonElement => jsonElement.GetInt32()).ToList();
+        }
+        catch (HttpRequestException httpRequestException) when (httpRequestException.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("Product not found in Migros: {Gtin}", gtin);
+            return ImmutableList<int>.Empty;
         }
         catch (HttpRequestException httpRequestException)
         {

--- a/GrocyScanner.Core/Providers/OpenFoodFactsProductProvider.cs
+++ b/GrocyScanner.Core/Providers/OpenFoodFactsProductProvider.cs
@@ -34,6 +34,11 @@ public class OpenFoodFactsProductProvider : IProductProvider
                 Categories = product.Product.CategoriesTags
             };
         }
+        catch (HttpRequestException httpRequestException) when (httpRequestException.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("Product not found in Open Food Facts: {Gtin}", gtin);
+            return null;
+        }
         catch (HttpRequestException httpRequestException)
         {
             _logger.LogError(httpRequestException, "Unable to request {Gtin}", gtin);

--- a/GrocyScanner.Service/Shared/Components/AddProductDialog.razor
+++ b/GrocyScanner.Service/Shared/Components/AddProductDialog.razor
@@ -7,6 +7,7 @@
 @inject IGrocyClient GrocyClient
 @inject IBestValueCalculator BestValueCalculator
 @inject ISnackbar Snackbar
+@inject ILogger<AddProductDialog> Logger
 
 <MudDialog>
     <DialogContent>
@@ -125,7 +126,18 @@
         // product is not known, must be searched in the providers
         if (productFromGrocy == null)
         {
-            Product?[] products = await Task.WhenAll(ProductProviders.Select(async provider => await provider.GetProductByGtin(Barcode)));
+            Product?[] products = await Task.WhenAll(ProductProviders.Select(async provider =>
+            {
+                try
+                {
+                    return await provider.GetProductByGtin(Barcode);
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e, "Error retrieving product from {ProviderName}", provider.GetType().Name);
+                    return null;
+                }
+            }));
             Product = BestValueCalculator.GetProductWithMostValue(products.Where(product => product != null).Cast<Product>().ToList());
             if (Product == null)
             {


### PR DESCRIPTION
Tries to address https://github.com/manuel-rw/grocy-scanner/issues/41
* Do not log exception for 404, just log that it cannot be found 
* Blanket catch any other exceptions on the frontend

Ideally this could be enhanced by catching the exceptions better in the providers, but this seems like a decent halfway fix. 