### PR TITLE
Fix: openfoodfacts: handle product with null name.

### DIFF
--- a/GrocyScanner.Core/Providers/OpenFoodFactsProductProvider.cs
+++ b/GrocyScanner.Core/Providers/OpenFoodFactsProductProvider.cs
@@ -26,13 +26,14 @@ public class OpenFoodFactsProductProvider : IProductProvider
                 return null;
             }
 
-            return new Product
+            var returnproduct = new Product
             {
                 Gtin = product.Code,
                 Name = product.Product.ProductName,
                 ImageUrl = product.Product.ImageUrl,
                 Categories = product.Product.CategoriesTags
             };
+            return returnproduct.Name == null ? null : returnproduct;
         }
         catch (HttpRequestException httpRequestException) when (httpRequestException.StatusCode == System.Net.HttpStatusCode.NotFound)
         {


### PR DESCRIPTION
Not sure what causes it, but this product: https://world.openfoodfacts.org/product/5414807007998/
Has a `null` name according to the client. The API does list it with a name, so I'm not sure what's going on. 
I suspect its something to do with OpenFoodFacts4Net, since it hasn't been updated in 3 years.

I might look into fixing either forking that library or just creating a solution inside grocy-scanner.
Anyway, a product with a null name shouldn't cause the application to crash, hence this fix.